### PR TITLE
Fix `finite_opt_saving.py` and `modified_opt_saving.py`

### DIFF
--- a/source_code_py/finite_opt_saving_1.py
+++ b/source_code_py/finite_opt_saving_1.py
@@ -1,7 +1,6 @@
 import numpy as np
 from finite_opt_saving_0 import U, B
 from numba import njit, prange
-from itertools import product
 
 @njit
 def cartesian_product(arrays):

--- a/source_code_py/finite_opt_saving_1.py
+++ b/source_code_py/finite_opt_saving_1.py
@@ -3,6 +3,31 @@ from finite_opt_saving_0 import U, B
 from numba import njit, prange
 from itertools import product
 
+@njit
+def cartesian_product(arrays):
+    arrays = [np.asarray(a) for a in arrays]
+    num_arrays = len(arrays)
+    lengths = np.zeros(num_arrays, dtype=np.int64)
+    for i in prange(num_arrays):
+        lengths[i] = len(arrays[i])
+    num_elements = np.prod(lengths)
+
+    result = np.zeros((num_elements, num_arrays), dtype=arrays[0].dtype)
+    temp_product = np.zeros(num_arrays, dtype=np.int64)
+
+    for i in prange(num_elements):
+        for j in prange(num_arrays):
+            result[i, j] = arrays[j][temp_product[j]]
+        
+        # Increment the temporary product
+        for j in prange(num_arrays - 1, -1, -1):
+            temp_product[j] += 1
+            if temp_product[j] == lengths[j] and j != 0:
+                temp_product[j] = 0
+            else:
+                break
+    return result
+
 
 @njit(parallel=True)
 def get_greedy(v, model):
@@ -22,7 +47,6 @@ def single_to_multi(m, yn):
     # Function to extract (i, j) from m = i + (j-1)*yn
     return (m//yn, m%yn)
 
-
 @njit(parallel=True)
 def get_value(σ, model):
     """Get the value v_σ of policy σ."""
@@ -34,14 +58,17 @@ def get_value(σ, model):
     # Build P_σ and r_σ as multi-index arrays
     P_σ = np.zeros((wn, yn, wn, yn))
     r_σ = np.zeros((wn, yn))
-    for (i, j) in product(w_idx, y_idx):
+    prd = cartesian_product([w_idx, y_idx])
+    for (i, j) in prd:
         w, y, w_1 = w_grid[i], y_grid[j], w_grid[σ[i, j]]
         r_σ[i, j] = U(w + y - w_1/R, γ)
-        for (i_1, j_1) in product(w_idx, y_idx):
+        for (i_1, j_1) in prd:
             if i_1 == σ[i, j]:
                 P_σ[i, j, i_1, j_1] = Q[j, j_1]
-
     # Solve for the value of σ
+    P_σ = P_σ.reshape(n, n)
+    r_σ = r_σ.reshape(n)
+
     I = np.identity(n)
     v_σ = np.linalg.solve((I - β * P_σ), r_σ)
     # Return as multi-index array

--- a/source_code_py/finite_opt_saving_1.py
+++ b/source_code_py/finite_opt_saving_1.py
@@ -3,25 +3,12 @@ from finite_opt_saving_0 import U, B
 from numba import njit, prange
 
 @njit(parallel=True)
-def cartesian_product(arr1, arr2):
-    len1 = len(arr1)
-    len2 = len(arr2)
-    result = np.empty((len1 * len2, 2), dtype=np.int64)
-
-    for i in prange(len1):
-        for j in prange(len2):
-            result[i * len2 + j, 0] = arr1[i]
-            result[i * len2 + j, 1] = arr2[j]
-
-    return result
-
-@njit(parallel=True)
 def get_greedy(v, model):
     """Compute a v-greedy policy."""
     β, R, γ, w_grid, y_grid, Q = model
     σ = np.empty((w_grid.shape[0], y_grid.shape[0]), dtype=np.int32)
     for i in prange(w_grid.shape[0]):
-        for j in prange(y_grid.shape[0]):
+        for j in range(y_grid.shape[0]):
             x_tmp = np.array([B(i, j, k, v, model) for k in
                              np.arange(w_grid.shape[0])])
             σ[i, j] = np.argmax(x_tmp)
@@ -38,19 +25,20 @@ def get_value(σ, model):
     """Get the value v_σ of policy σ."""
     # Unpack and set up
     β, R, γ, w_grid, y_grid, Q = model
-    w_idx, y_idx = np.arange(len(w_grid)), np.arange(len(y_grid))
     wn, yn = len(w_grid), len(y_grid)
     n = wn * yn
     # Build P_σ and r_σ as multi-index arrays
     P_σ = np.zeros((wn, yn, wn, yn))
     r_σ = np.zeros((wn, yn))
-    prd = cartesian_product(w_idx, y_idx)
-    for (i, j) in prd:
-        w, y, w_1 = w_grid[i], y_grid[j], w_grid[σ[i, j]]
-        r_σ[i, j] = U(w + y - w_1/R, γ)
-        for (i_1, j_1) in prd:
-            if i_1 == σ[i, j]:
-                P_σ[i, j, i_1, j_1] = Q[j, j_1]
+    for i in range(wn):
+        for j in range(yn):
+            w, y, w_1 = w_grid[i], y_grid[j], w_grid[σ[i, j]]
+            r_σ[i, j] = U(w + y - w_1/R, γ)
+            for i_1 in range(wn):
+                for j_1 in range(yn):
+                    if i_1 == σ[i, j]:
+                        P_σ[i, j, i_1, j_1] = Q[j, j_1]
+
     # Solve for the value of σ
     P_σ = P_σ.reshape(n, n)
     r_σ = r_σ.reshape(n)
@@ -60,4 +48,5 @@ def get_value(σ, model):
     # Return as multi-index array
     v_σ = v_σ.reshape(wn, yn)
     return v_σ
+
 

--- a/source_code_py/finite_opt_saving_2.py
+++ b/source_code_py/finite_opt_saving_2.py
@@ -156,11 +156,12 @@ def plot_time_series(m=2_000, savefig=False):
 def plot_histogram(m=1_000_000, savefig=False):
 
     w_series = simulate_wealth(m)
-    g = round(gini(w_series.sort()), ndigits=2)
+    w_series.sort()
+    g = round(gini(w_series), ndigits=2)
     fig, ax = plt.subplots(figsize=(9, 5.2))
     ax.hist(w_series, bins=40, density=True)
     ax.set_xlabel("wealth")
-    ax.text(15, 0.4, "Gini = $g")
+    ax.text(15, 0.4, f"Gini = {g}")
     plt.show()
 
     if savefig:
@@ -169,7 +170,8 @@ def plot_histogram(m=1_000_000, savefig=False):
 def plot_lorenz(m=1_000_000, savefig=False):
 
     w_series = simulate_wealth(m)
-    (F, L) = lorenz(w_series.sort())
+    w_series.sort()
+    (F, L) = lorenz(w_series)
 
     fig, ax = plt.subplots(figsize=(9, 5.2))
     ax.plot(F, F, label="Lorenz curve, equality")
@@ -179,3 +181,5 @@ def plot_lorenz(m=1_000_000, savefig=False):
 
     if savefig:
         fig.savefig("../figures/finite_opt_saving_lorenz.pdf")
+
+plot_timing()

--- a/source_code_py/finite_opt_saving_2.py
+++ b/source_code_py/finite_opt_saving_2.py
@@ -16,7 +16,7 @@ def value_iteration(model, tol=1e-5):
     return get_greedy(v_star, model)
 
 
-@njit
+@njit(cache=True, fastmath=True)
 def policy_iteration(model):
     """Howard policy iteration routine."""
     wn, yn = len(model.w_grid), len(model.y_grid)
@@ -181,3 +181,9 @@ def plot_lorenz(m=1_000_000, savefig=False):
 
     if savefig:
         fig.savefig("../figures/finite_opt_saving_lorenz.pdf")
+
+plot_timing()
+plot_policy()
+plot_time_series()
+plot_histogram()
+plot_lorenz()

--- a/source_code_py/finite_opt_saving_2.py
+++ b/source_code_py/finite_opt_saving_2.py
@@ -181,9 +181,3 @@ def plot_lorenz(m=1_000_000, savefig=False):
 
     if savefig:
         fig.savefig("../figures/finite_opt_saving_lorenz.pdf")
-
-plot_timing()
-plot_policy()
-plot_time_series()
-plot_histogram()
-plot_lorenz()

--- a/source_code_py/finite_opt_saving_2.py
+++ b/source_code_py/finite_opt_saving_2.py
@@ -181,5 +181,3 @@ def plot_lorenz(m=1_000_000, savefig=False):
 
     if savefig:
         fig.savefig("../figures/finite_opt_saving_lorenz.pdf")
-
-plot_timing()

--- a/source_code_py/modified_opt_savings.py
+++ b/source_code_py/modified_opt_savings.py
@@ -278,9 +278,3 @@ def plot_lorenz(m=1_000_000, savefig=False):
 
     if savefig:
         fig.savefig("../figures/modified_opt_saving_lorenz.pdf")
-
-plot_contours()
-plot_policies()
-plot_time_series()
-plot_histogram()
-plot_lorenz()


### PR DESCRIPTION
Hi @orectique, @jstac, and @Smit-create,

This PR fixes small bugs in `finite_opt_saving.py`.

Although this code can be run and draw the same plots without error, the HPI is significantly slower compared to the graph in the book. One reason is that `itertools.product` is incompatible with Numba, and I have to homebrew an easy Numba-compatible version of `cartesian_product`. I have tried other Numba-compatible implementations of the Cartesian product, but the speed is roughly the same. 

![Figure_1](https://github.com/orectique/book-dp1/assets/39026988/4aeae764-bedd-4ebb-8071-8db280e7cd97)

There might be other factors causing HPI to be slower.